### PR TITLE
Let sort indicator render on the same line as a column's icon

### DIFF
--- a/src/columns.js
+++ b/src/columns.js
@@ -45,18 +45,25 @@ export const columns = [
   {
     id: "playerCount",
     Header: (
+      <>
       <span>
-        Players <FontAwesomeIcon icon={faUsers} fixedWidth />
+        Players{" "}
       </span>
+      <FontAwesomeIcon icon={faUsers} fixedWidth />
+      </>
+
     ),
     accessor: (game) => `${game.minPlayers}-${game.maxPlayers}`,
     className: "d-none d-sm-table-cell"
   },
   {
     Header: (
-      <span className="d-none d-sm-table-cell">
-        Family Friendly Setting <FontAwesomeIcon icon={faChild} fixedWidth />
-      </span>
+      <>
+        <span className="d-none d-sm-table-cell">
+          Family Friendly Setting{" "}
+        </span>
+        <FontAwesomeIcon icon={faChild} fixedWidth />
+      </>
     ),
     accessor: "familyFriendlySetting",
     className: "text-center",
@@ -65,9 +72,12 @@ export const columns = [
   },
   {
     Header: (
-      <span className="d-none d-sm-table-cell">
-        Manual Censoring <FontAwesomeIcon icon={faBan} fixedWidth />
-      </span>
+      <>
+        <span className="d-none d-sm-table-cell">
+          Manual Censoring{" "}
+        </span>
+        <FontAwesomeIcon icon={faBan} fixedWidth />
+      </>
     ),
     accessor: "manualCensoring",
     className: "text-center",
@@ -76,9 +86,12 @@ export const columns = [
   },
   {
     Header: (
-      <span className="d-none d-sm-table-cell">
-        Extended Timers <FontAwesomeIcon icon={faStopwatch} fixedWidth />
-      </span>
+      <>
+        <span className="d-none d-sm-table-cell">
+          Extended Timers{" "}
+        </span>
+        <FontAwesomeIcon icon={faStopwatch} fixedWidth />
+      </>
     ),
     accessor: "extendedTimers",
     Cell: BoolCell,


### PR DESCRIPTION
In https://github.com/spilth/jackbox-decider/pull/20 I inadvertently changed the header rendering so that the icons were also wrapped in the styled span. This reverts that subtle change so that the new sort indicators can render adjacent to the other icon, rather than below.

# Before

![2021-11-18 15 29 02](https://user-images.githubusercontent.com/1744567/142492218-bcd14fa3-704c-4a9a-8a7a-f8fb68c9c7f9.gif)

# After
![2021-11-18 15 28 39](https://user-images.githubusercontent.com/1744567/142492230-a6fd33c1-008c-4a1f-a1f6-013d6295c3eb.gif)


