### PR TITLE
Actually use Bootstrap React components and clean up spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.3.0",
-    "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
     "bootstrap": "^5.1.3",
     "react": "^17.0.2",

--- a/src/GameCards.js
+++ b/src/GameCards.js
@@ -1,75 +1,73 @@
 import React from "react";
 import {
-  faChild,
+  faChildReaching,
   faHourglass,
   faCommentSlash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Card, Col, Row, Stack } from "react-bootstrap";
 
 const GameCards = ({ games }) => {
   return (
-    <div className="row row-cols-1 row-cols-md-3 g-4 mb-4">
+    <Row xs={1} sm={2} md={2} lg={3} xl={3} xxl={3}>
+      {/*<div className="row row-cols-1 row-cols-md-3 g-4 mb-4">*/}
       {games.map((game) => {
         return (
-          <div className="col" key={game.name}>
-            <div className="card mb-2">
+          <Col key={game.name}>
+            <Card className="mb-4 shadow">
               {game.image && (
                 <a href={game.url}>
-                  <img
-                    src={`/images/${game.image}`}
-                    className="card-img-top"
-                    alt={game.name}
-                  />
+                  <Card.Img variant="top" src={`/images/${game.image}`} />
                 </a>
               )}
-              <div className="card-body">
-                <h5 className="card-title">
+              <Card.Body>
+                <Card.Title>
                   <a href={game.url} className="text-decoration-none">
                     {game.name}
                   </a>
-                </h5>
-                <h6 className="card-subtitle text-muted">
+                </Card.Title>
+                <Card.Subtitle className="text-muted mb-2">
                   {game.minPlayers} - {game.maxPlayers} players
-                </h6>
-                <p className="card-text">{game.description}</p>
-              </div>
-              <ul className="list-group list-group-flush">
-                {game.familyFriendlySetting && (
-                  <li className="list-group-item">
-                    <FontAwesomeIcon icon={faChild} fixedWidth /> Family
-                    Friendly Setting
-                  </li>
-                )}
-                {game.manualCensoring && (
-                  <li className="list-group-item">
-                    <FontAwesomeIcon icon={faCommentSlash} fixedWidth /> Manual
-                    Censoring
-                  </li>
-                )}
-                {game.extendedTimers && (
-                  <li className="list-group-item">
-                    <FontAwesomeIcon icon={faHourglass} fixedWidth /> Extended
-                    Timers
-                  </li>
-                )}
-              </ul>
-              <div className="card-footer">
+                </Card.Subtitle>
+                <Card.Text>{game.description}</Card.Text>
+                <Stack direction="vertical" gap={1}>
+                  {game.familyFriendlySetting && (
+                    <div>
+                      <FontAwesomeIcon icon={faChildReaching} fixedWidth />{" "}
+                      Family Friendly Setting
+                    </div>
+                  )}
+                  {game.manualCensoring && (
+                    <div>
+                      <FontAwesomeIcon icon={faCommentSlash} fixedWidth />{" "}
+                      Manual Censoring
+                    </div>
+                  )}
+                  {game.extendedTimers && (
+                    <div>
+                      <FontAwesomeIcon icon={faHourglass} fixedWidth /> Extended
+                      Timers
+                    </div>
+                  )}
+                </Stack>
+              </Card.Body>
+              <Card.Footer>
                 {game.pack_url ? (
-                  <span>
+                  <>
                     Part of{" "}
                     <a href={game.pack_url} className="text-decoration-none">
                       {game.pack}
                     </a>
-                  </span>
+                  </>
                 ) : (
-                  <span>{game.pack}</span>
+                  <>{game.pack}</>
                 )}
-              </div>
-            </div>
-          </div>
+              </Card.Footer>
+            </Card>
+          </Col>
         );
       })}
-    </div>
+    </Row>
   );
 };
 

--- a/src/GameCards.js
+++ b/src/GameCards.js
@@ -10,7 +10,6 @@ import { Card, Col, Row, Stack } from "react-bootstrap";
 const GameCards = ({ games }) => {
   return (
     <Row xs={1} sm={2} md={2} lg={3} xl={3} xxl={3}>
-      {/*<div className="row row-cols-1 row-cols-md-3 g-4 mb-4">*/}
       {games.map((game) => {
         return (
           <Col key={game.name}>
@@ -53,14 +52,14 @@ const GameCards = ({ games }) => {
               </Card.Body>
               <Card.Footer>
                 {game.pack_url ? (
-                  <>
+                  <React.Fragment>
                     Part of{" "}
                     <a href={game.pack_url} className="text-decoration-none">
                       {game.pack}
                     </a>
-                  </>
+                  </React.Fragment>
                 ) : (
-                  <>{game.pack}</>
+                  <React.Fragment>{game.pack}</React.Fragment>
                 )}
               </Card.Footer>
             </Card>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,10 +1982,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-common-types@^0.2.36":
-  version "0.2.36"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
-  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+"@fortawesome/fontawesome-common-types@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz#7dc996042d21fc1ae850e3173b5c67b0549f9105"
+  integrity sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA==
 
 "@fortawesome/fontawesome-common-types@^0.3.0":
   version "0.3.0"
@@ -1999,12 +1999,12 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.3.0"
 
-"@fortawesome/free-solid-svg-icons@^5.15.4":
-  version "5.15.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
-  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+"@fortawesome/free-solid-svg-icons@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz#3369e673f8fe8be2fba30b1ec274d47490a830a6"
+  integrity sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.36"
+    "@fortawesome/fontawesome-common-types" "6.1.1"
 
 "@fortawesome/react-fontawesome@^0.1.18":
   version "0.1.18"


### PR DESCRIPTION
We were important react-bootstrap but not actually using the components it provides. This PR switches to using those components.

It also does a bit of styling cleanup.

## Screenshots

### Before

<img width="1318" alt="Screen Shot 2022-05-08 at 5 39 55 PM" src="https://user-images.githubusercontent.com/13157/167319065-c161eaf3-c9d1-4d1f-b08d-37a6f7311360.png">

### After

<img width="1321" alt="Screen Shot 2022-05-08 at 5 46 28 PM" src="https://user-images.githubusercontent.com/13157/167319072-906ba8ab-9e9d-4b57-9dcd-9e3fe96a3806.png">

